### PR TITLE
Add support to tweet memes

### DIFF
--- a/libiomeme-www/DEBIAN/conffiles
+++ b/libiomeme-www/DEBIAN/conffiles
@@ -1,2 +1,3 @@
 /etc/nginx/sites-available/iomeme
 /etc/iomeme/hypnotoad.conf
+/etc/iomeme/iomeme.yaml

--- a/libiomeme-www/DEBIAN/control
+++ b/libiomeme-www/DEBIAN/control
@@ -5,6 +5,9 @@ Architecture: all
 Depends: nginx,
          libiomeme-perl,
          libmojolicious-perl,
-         libcache-fastmmap-perl
+         libcache-fastmmap-perl,
+         libnet-oauth-perl,
+         libnet-twitter-lite-perl,
+         libyaml-libyaml-perl
 Maintainer: Justin Pacheco (justinjpacheco@gmail.com)
 Description: website for iomeme (yet another meme generator)

--- a/libiomeme-www/etc/iomeme/iomeme.yaml
+++ b/libiomeme-www/etc/iomeme/iomeme.yaml
@@ -1,0 +1,10 @@
+
+twitter:
+    twitter_enabled : 0
+    twitter_message : "New meme at iome.me - "
+
+    consumer_key        : ' '
+    consumer_secret     : ' '
+    access_token        : ' '
+    access_token_secret : ' '
+


### PR DESCRIPTION
To create twitter keys:
- Go here: https://dev.twitter.com/apps/new
- Login
- Enter application name, description and website.
- Open settings, change from read only to read and write.
- Click "create access token".
- Copy consumer_key, consumer_secret, access_token, and access_token_secret to /etc/iomeme/iomeme.yaml
- Set twitter_enabled = 1 in /etc/iomeme/iomeme.yaml
