### PR TITLE
Update Meme Tweeting.

### DIFF
--- a/lib/IOMeme/Main.pm
+++ b/lib/IOMeme/Main.pm
@@ -122,12 +122,15 @@ sub render_meme {
         access_token        => $config->{twitter}->{'access_token'},
         access_token_secret => $config->{twitter}->{'access_token_secret'}
       );
+      
+      my $hashtag = $memes->{$meme}->{name};
+      $hashtag =~ s/ //g;
 
       try {
         $nt->update(
           $config->{twitter}->{'message'} .
-          $url->to_abs() .
-          " #$meme"
+          "http://iome.me" . $url .
+          " #" . $hashtag
         );
       } catch {
         $self->app->log->warn("Posting meme to twitter failed: $_");


### PR DESCRIPTION
- Stop tweeting empty memes.
- Add meme name to tweet as hashtag.
  - Use full meme name as hashtag
- Add hardcoded domain to tweet url
